### PR TITLE
Barebones example of Softmax to compare with Zig implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+
+xor-graph.png

--- a/activations.py
+++ b/activations.py
@@ -1,6 +1,7 @@
 import numpy as np
 from layer import Layer
 from activation import Activation
+import logging
 
 class Tanh(Activation):
     def __init__(self):
@@ -32,6 +33,9 @@ class Softmax(Layer):
     def backward(self, output_gradient, learning_rate):
         # This version is faster than the one presented in the video
         n = np.size(self.output)
+        logging.error("\tSoftmax backward: asdf %s", (np.identity(n) - self.output.T) * self.output)
+        logging.error("\tSoftmax backward: output_gradient %s", output_gradient)
+        logging.error("\tSoftmax backward: result %s", np.dot((np.identity(n) - self.output.T) * self.output, output_gradient))
         return np.dot((np.identity(n) - self.output.T) * self.output, output_gradient)
         # Original formula:
         # tmp = np.tile(self.output, n)

--- a/dense.py
+++ b/dense.py
@@ -1,5 +1,6 @@
 import numpy as np
 from layer import Layer
+import logging
 
 class Dense(Layer):
     def __init__(self, input_size, output_size):
@@ -12,7 +13,10 @@ class Dense(Layer):
 
     def backward(self, output_gradient, learning_rate):
         weights_gradient = np.dot(output_gradient, self.input.T)
+        logging.error("\tweights_gradient %s", weights_gradient)
         input_gradient = np.dot(self.weights.T, output_gradient)
         self.weights -= learning_rate * weights_gradient
+        logging.error("\tbias: cost gradient %s", output_gradient)
         self.bias -= learning_rate * output_gradient
+        logging.error("\tinput_gradient %s", input_gradient)
         return input_gradient

--- a/network.py
+++ b/network.py
@@ -1,3 +1,5 @@
+import logging
+
 def predict(network, input):
     output = input
     for layer in network:
@@ -16,8 +18,11 @@ def train(network, loss, loss_prime, x_train, y_train, epochs = 1000, learning_r
 
             # backward
             grad = loss_prime(y, output)
+            layer_index = len(network) - 1
             for layer in reversed(network):
+                logging.error("layer %s", layer_index)
                 grad = layer.backward(grad, learning_rate)
+                layer_index -= 1
 
         error /= len(x_train)
         if verbose:

--- a/xor.py
+++ b/xor.py
@@ -9,12 +9,13 @@ from losses import mse, mse_prime
 from network import train, predict
 
 X = np.reshape([[0, 0], [0, 1], [1, 0], [1, 1]], (4, 2, 1))
-Y = np.reshape([[1, 0], [0, 1], [0, 1], [1, 0]], (4, 2, 1))
+# Y = np.reshape([[1, 0], [0, 1], [0, 1], [1, 0]], (4, 2, 1))
+Y = np.reshape([[1, 0, 0], [0, 1, 0], [0, 1, 0], [1, 0, 0]], (4, 3, 1))
 
 network = [
     Dense(2, 3),
     Sigmoid(),
-    Dense(3, 2),
+    Dense(3, 3),
     Softmax()
 ]
 
@@ -38,11 +39,19 @@ network[0].bias = np.array([
 network[2].weights = np.array([
     [2.6545684575714984e-01, 8.636176515580903e-01, 2.953281182408529e-01],
     [1.1489972410202928e-02, -1.0382172576148672e+00, 2.655416761236997e-01],
+    [4.8858481453740094e-01, 4.2309380092781346e-01, 1.0127531494214492e+00],
 ])
 network[2].bias = np.array([
     [1.0e-01],
     [1.0e-01],
+    [1.0e-01],
 ])
+
+for layer in network:
+    if hasattr(layer, 'weights'):
+        logging.error("layer.weights %s %s", layer.weights.shape, layer.weights)
+    if hasattr(layer, 'bias'):
+        logging.error("layer.bias %s %s", layer.bias.shape, layer.bias)
 
 # train
 train(network, mse, mse_prime, X, Y, epochs=1, learning_rate=0.1)

--- a/xor.py
+++ b/xor.py
@@ -1,35 +1,67 @@
 import numpy as np
 import matplotlib.pyplot as plt
 #from mpl_toolkits.mplot3d import Axes3D
+import logging
 
 from dense import Dense
-from activations import Tanh
+from activations import Sigmoid, Softmax
 from losses import mse, mse_prime
 from network import train, predict
 
 X = np.reshape([[0, 0], [0, 1], [1, 0], [1, 1]], (4, 2, 1))
-Y = np.reshape([[0], [1], [1], [0]], (4, 1, 1))
+Y = np.reshape([[1, 0], [0, 1], [0, 1], [1, 0]], (4, 2, 1))
 
 network = [
     Dense(2, 3),
-    Tanh(),
-    Dense(3, 1),
-    Tanh()
+    Sigmoid(),
+    Dense(3, 2),
+    Softmax()
 ]
 
+# for layer in network:
+#     if hasattr(layer, 'weights'):
+#         logging.error("layer.weights %s %s", layer.weights.shape, layer.weights)
+#     if hasattr(layer, 'bias'):
+#         logging.error("layer.bias %s %s", layer.bias.shape, layer.bias)
+
+# Match the initial weights and biases from our Zig implementaiton
+network[0].weights = np.array([
+  [3.251169104168574e-01, 1.0577112895890197e+00],
+  [3.6170159819321346e-01, 1.4072284781826894e-02],
+  [-1.271551261654049e+00, 3.2522080597322767e-01],
+])
+network[0].bias = np.array([
+    [1.0e-01],
+    [1.0e-01],
+    [1.0e-01],
+])
+network[2].weights = np.array([
+    [2.6545684575714984e-01, 8.636176515580903e-01, 2.953281182408529e-01],
+    [1.1489972410202928e-02, -1.0382172576148672e+00, 2.655416761236997e-01],
+])
+network[2].bias = np.array([
+    [1.0e-01],
+    [1.0e-01],
+])
+
 # train
-train(network, mse, mse_prime, X, Y, epochs=10000, learning_rate=0.1)
+train(network, mse, mse_prime, X, Y, epochs=1, learning_rate=0.1)
 
 # decision boundary plot
 points = []
 for x in np.linspace(0, 1, 20):
     for y in np.linspace(0, 1, 20):
         z = predict(network, [[x], [y]])
-        points.append([x, y, z[0,0]])
+        # logging.error(f"network prediction for x={x} y={y} -> z={np.argmax(z)}")
+        points.append([x, y, np.argmax(z)])
 
 points = np.array(points)
 
 fig = plt.figure()
 ax = fig.add_subplot(111, projection="3d")
 ax.scatter(points[:, 0], points[:, 1], points[:, 2], c=points[:, 2], cmap="winter")
+# Show the plot for interactive use
 plt.show()
+# Save out the plot to a file so headless console people can see observe what's
+# happening
+plt.savefig("xor-graph.png")


### PR DESCRIPTION
Barebones example of Softmax to compare with Zig implementation

Compare against Zig implementation,
https://github.com/MadLittleMods/zig-ocr-neural-network/pull/20



## Dev notes


### Using `Sigmoid`  (layers: 2, 3, 2)

 - Layers: 2, 3, 2
 - Activation: `Sigmoid`
 - Output activation: `Sigmoid`
 - Cost: MSE/`SquaredError`

The cost gradients for the weight and biases match between the implementations :white_check_mark: 

**Using the [Zig implementation](https://github.com/MadLittleMods/zig-ocr-neural-network/pull/20):**
```
$ zig build run-xor
debug: layer 0:
        weights { 3.251169104168574e-01, 1.0577112895890197e+00, 3.6170159819321346e-01, 1.4072284781826894e-02, -1.271551261654049e+00, 3.2522080597322767e-01 }
        biases: { 1.0e-01, 1.0e-01, 1.0e-01 }
debug: layer 1:
        weights { 2.6545684575714984e-01, 8.636176515580903e-01, 2.953281182408529e-01, 1.1489972410202928e-02, -1.0382172576148672e+00, 2.655416761236997e-01 }
        biases: { 1.0e-01, 1.0e-01 }
error: asdf
    Estimated weight gradient: { -0.033056, -0.033056, -0.033056, 0.054630, 0.054630, 0.054630 }
       Actual weight gradient: { -0.033056, -0.033056, -0.033056, 0.054630, 0.054630, 0.054630 }
    Estimated bias gradient: { -0.062966, 0.104061 }
       Actual bias gradient: { -0.062966, 0.104061 }
```


**Using `TheIndependentCode-Neural-Network`:**

```sh
$ poetry run python xor.py
[...]
ERROR:root:layer 2
ERROR:root:     weights_gradient [[-0.03305609 -0.03305609 -0.03305609]
 [ 0.05462968  0.05462968  0.05462968]]
ERROR:root:     bias: cost gradient [[-0.06296647]
 [ 0.10406066]]
ERROR:root:     input_gradient [[-0.01551923]
 [-0.16241653]
 [ 0.00903667]]
 ```


### Using `Sigmoid`  (layers: 2, 3, 3)

 - Layers: 2, 3, 3
 - Activation: `Sigmoid`
 - Output activation: `Sigmoid`
 - Cost: MSE/`SquaredError`

The cost gradients for the weight and biases do *NOT* match between the implementations :x: 

**Using the [Zig implementation](https://github.com/MadLittleMods/zig-ocr-neural-network/pull/20):**

```
zig build run-xor
debug: layer 0:
        weights { 3.251169104168574e-01, 1.0577112895890197e+00, 3.6170159819321346e-01, 1.4072284781826894e-02, -1.271551261654049e+00, 3.2522080597322767e-01 }
        biases: { 1.0e-01, 1.0e-01, 1.0e-01 }
debug: layer 1:
        weights { 2.6545684575714984e-01, 8.636176515580903e-01, 2.953281182408529e-01, 1.1489972410202928e-02, -1.0382172576148672e+00, 2.655416761236997e-01, 4.8858481453740094e-01, 4.2309380092781346e-01, 1.0127531494214492e+00 }
        biases: { 1.0e-01, 1.0e-01, 1.0e-01 }
error: asdf
    Estimated weight gradient: { -0.033056, -0.033056, -0.033056, 0.054630, 0.054630, 0.054630, 0.073607, 0.073607, 0.073607 }
       Actual weight gradient: { -0.033056, -0.033056, -0.033056, 0.054630, 0.054630, 0.054630, 0.073607, 0.073607, 0.073607 }
    Estimated bias gradient: { -0.062966, 0.104061, 0.140210 }
       Actual bias gradient: { -0.062966, 0.104061, 0.140210 }
```


**Using `TheIndependentCode-Neural-Network`:**

```sh
$ poetry run python xor.py
ERROR:root:layer.weights (3, 2) [[ 0.32511691  1.05771129]
 [ 0.3617016   0.01407228]
 [-1.27155126  0.32522081]]
ERROR:root:layer.bias (3, 1) [[0.1]
 [0.1]
 [0.1]]
ERROR:root:layer.weights (3, 3) [[ 0.26545685  0.86361765  0.29532812]
 [ 0.01148997 -1.03821726  0.26554168]
 [ 0.48858481  0.4230938   1.01275315]]
ERROR:root:layer.bias (3, 1) [[0.1]
 [0.1]
 [0.1]]
[...]
ERROR:root:layer 2
ERROR:root:     weights_gradient [[-0.02203739 -0.02203739 -0.02203739]
 [ 0.03641979  0.03641979  0.03641979]
 [ 0.04907149  0.04907149  0.04907149]]
ERROR:root:     bias: cost gradient [[-0.04197765]
 [ 0.06937378]
 [ 0.09347321]]
ERROR:root:     input_gradient [[ 0.03532344]
 [-0.06872976]
 [ 0.10068973]]
```


 
 ### Using `SoftMax` (layers: 2, 3, 2)
 
 - Layers: 2, 3, 2
 - Activation: `Sigmoid`
 - Output activation: `SoftMax`
 - Cost: MSE/`SquaredError`

The :exclamation: estimated :exclamation:  cost gradients for the weight and biases from the Zig implementation match the Python implementation :x:

**Using the [Zig implementation](https://github.com/MadLittleMods/zig-ocr-neural-network/pull/20):**
```
$ zig build run-xor
debug: layer 0:
        weights { 3.251169104168574e-01, 1.0577112895890197e+00, 3.6170159819321346e-01, 1.4072284781826894e-02, -1.271551261654049e+00, 3.2522080597322767e-01 }
        biases: { 1.0e-01, 1.0e-01, 1.0e-01 }
debug: layer 1:
        weights { 2.6545684575714984e-01, 8.636176515580903e-01, 2.953281182408529e-01, 1.1489972410202928e-02, -1.0382172576148672e+00, 2.655416761236997e-01 }
        biases: { 1.0e-01, 1.0e-01 }
error: asdf
    Estimated weight gradient: { -0.046275, -0.046275, -0.046275, 0.046275, 0.046275, 0.046275 }
       Actual weight gradient: { -0.023137, -0.023137, -0.023137, 0.023137, 0.023137, 0.023137 }
    Estimated bias gradient: { -0.088146, 0.088146 }
       Actual bias gradient: { -0.044073, 0.044073 }
error: Relative error for index 0 in weight gradient was too high (0.5000000002482324).
error: Relative error for index 1 in weight gradient was too high (0.5000000002482324).
error: Relative error for index 2 in weight gradient was too high (0.5000000002482324).
error: Relative error for index 3 in weight gradient was too high (0.500000000249732).
error: Relative error for index 4 in weight gradient was too high (0.5000000002486074).
error: Relative error for index 5 in weight gradient was too high (0.500000000249732).
error: Relative error for index 0 in bias gradient was too high (0.5000000009022944).
error: Relative error for index 1 in bias gradient was too high (0.5000000009013104).
warning: The first relative error we found is 0.5000000002482324 (should be ~0 which indicates the estimated and actual gradients match) which means our actual cost gradient values are some multiple of the estimated weight gradient. The relative error is the different across the entire gradient which means the gradient is pointing in a totally different direction than it should. Our backpropagation algorithm is probably wrong.
    Estimated weight gradient: { -0.046275, -0.046275, -0.046275, 0.046275, 0.046275, 0.046275 }
       Actual weight gradient: { -0.023137, -0.023137, -0.023137, 0.023137, 0.023137, 0.023137 }
    Estimated bias gradient: { -0.088146, 0.088146 }
       Actual bias gradient: { -0.044073, 0.044073 }
error: Relative error in cost gradients was too high meaning that some values in the estimated vs actual cost gradients were too different which means our backpropagation algorithm is probably wrong and we're probably stepping in an arbitrarily wrong direction.
    Estimated weight gradient: { -0.046275, -0.046275, -0.046275, 0.046275, 0.046275, 0.046275 }
       Actual weight gradient: { -0.023137, -0.023137, -0.023137, 0.023137, 0.023137, 0.023137 }
    Estimated bias gradient: { -0.088146, 0.088146 }
       Actual bias gradient: { -0.044073, 0.044073 }
error: RelativeErrorTooHigh
```


**Using `TheIndependentCode-Neural-Network`:**

```sh
$ poetry run python xor.py
[...]
ERROR:root:layer 2
ERROR:root:     weights_gradient [[-0.04627497 -0.04627497 -0.04627497]
 [ 0.04627497  0.04627497  0.04627497]]
ERROR:root:     bias: cost gradient [[-0.0881463]
 [ 0.0881463]]
ERROR:root:     input_gradient [[-0.02238624]
 [-0.16763971]
 [-0.00262556]]
 ```
 

 ### Using `SoftMax` (layers: 2, 3, 3)
 
 - Layers: 2, 3, 3
 - Activation: `Sigmoid`
 - Output activation: `SoftMax`
 - Cost: MSE/`SquaredError`


The cost gradients for the weight and biases do *NOT* match between the implementations :x: 


**Using the [Zig implementation](https://github.com/MadLittleMods/zig-ocr-neural-network/pull/20):**

```
$ zig build run-xor
debug: layer 0:
        weights { 3.251169104168574e-01, 1.0577112895890197e+00, 3.6170159819321346e-01, 1.4072284781826894e-02, -1.271551261654049e+00, 3.2522080597322767e-01 }
        biases: { 1.0e-01, 1.0e-01, 1.0e-01 }
debug: layer 1:
        weights { 2.6545684575714984e-01, 8.636176515580903e-01, 2.953281182408529e-01, 1.1489972410202928e-02, -1.0382172576148672e+00, 2.655416761236997e-01, 4.8858481453740094e-01, 4.2309380092781346e-01, 1.0127531494214492e+00 }
        biases: { 1.0e-01, 1.0e-01, 1.0e-01 }
error: asdf
    Estimated weight gradient: { -0.129019, -0.129019, -0.129019, 0.006108, 0.006108, 0.006108, 0.122911, 0.122911, 0.122911 }
       Actual weight gradient: { -0.076591, -0.076591, -0.076591, 0.006785, 0.006785, 0.006785, 0.065186, 0.065186, 0.065186 }
    Estimated bias gradient: { -0.245761, 0.011636, 0.234125 }
       Actual bias gradient: { -0.145893, 0.012925, 0.124169 }
error: Relative error for index 0 in weight gradient was too high (0.4063615602148346).
error: Relative error for index 1 in weight gradient was too high (0.4063615602148346).
error: Relative error for index 2 in weight gradient was too high (0.4063615602148346).
error: Relative error for index 3 in weight gradient was too high (0.09973303951549993).
error: Relative error for index 4 in weight gradient was too high (0.09973303951549993).
error: Relative error for index 5 in weight gradient was too high (0.09973303951549993).
error: Relative error for index 6 in weight gradient was too high (0.46964504818666053).
error: Relative error for index 7 in weight gradient was too high (0.4696450481842653).
error: Relative error for index 8 in weight gradient was too high (0.46964504818666053).
error: Relative error for index 0 in bias gradient was too high (0.4063615597223713).
error: Relative error for index 1 in bias gradient was too high (0.09973303544271393).
error: Relative error for index 2 in bias gradient was too high (0.46964504786908395).
warning: The first relative error we found is 0.4063615602148346 (should be ~0 which indicates the estimated and actual gradients match) which means our actual cost gradient values are some multiple of the estimated weight gradient. The relative error is the different across the entire gradient which means the gradient is pointing in a totally different direction than it should. Our backpropagation algorithm is probably wrong.
    Estimated weight gradient: { -0.129019, -0.129019, -0.129019, 0.006108, 0.006108, 0.006108, 0.122911, 0.122911, 0.122911 }
       Actual weight gradient: { -0.076591, -0.076591, -0.076591, 0.006785, 0.006785, 0.006785, 0.065186, 0.065186, 0.065186 }
    Estimated bias gradient: { -0.245761, 0.011636, 0.234125 }
       Actual bias gradient: { -0.145893, 0.012925, 0.124169 }
error: Relative error in cost gradients was too high meaning that some values in the estimated vs actual cost gradients were too different which means our backpropagation algorithm is probably wrong and we're probably stepping in an arbitrarily wrong direction.
    Estimated weight gradient: { -0.129019, -0.129019, -0.129019, 0.006108, 0.006108, 0.006108, 0.122911, 0.122911, 0.122911 }
       Actual weight gradient: { -0.076591, -0.076591, -0.076591, 0.006785, 0.006785, 0.006785, 0.065186, 0.065186, 0.065186 }
    Estimated bias gradient: { -0.245761, 0.011636, 0.234125 }
       Actual bias gradient: { -0.145893, 0.012925, 0.124169 }
error: RelativeErrorTooHigh
```


**Using `TheIndependentCode-Neural-Network`:**

```
poetry run python xor.py
[...]
ERROR:root:layer 2
ERROR:root:     weights_gradient [[-0.08601281 -0.08601281 -0.08601281]
 [ 0.00407232  0.00407232  0.00407232]
 [ 0.08194048  0.08194048  0.08194048]]
ERROR:root:     bias: cost gradient [[-0.16384041]
 [ 0.00775711]
 [ 0.1560833 ]]
ERROR:root:     input_gradient [[ 0.0328565 ]
 [-0.08351116]
 [ 0.11174701]]
 ```
 
 